### PR TITLE
Add SEO metadata and create missing site pages

### DIFF
--- a/bundles.html
+++ b/bundles.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Bundles</title>
+  <meta name="description" content="Discover discounted bundles of premium digital assets for filmmakers.">
+  <link rel="canonical" href="https://www.cineassets.com/bundles.html">
+  <meta property="og:title" content="CineAssets | Bundles">
+  <meta property="og:description" content="Discover discounted bundles of premium digital assets for filmmakers.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Bundles</h1>
+    <p class="text-gray-300">Find value-packed bundles to kickstart your next project.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Contact</title>
+  <meta name="description" content="Get in touch with the CineAssets team.">
+  <link rel="canonical" href="https://www.cineassets.com/contact.html">
+  <meta property="og:title" content="CineAssets | Contact">
+  <meta property="og:description" content="Get in touch with the CineAssets team.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Contact Us</h1>
+    <p class="text-gray-300">We would love to hear from you. Reach out with any questions or comments.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | FAQ</title>
+  <meta name="description" content="Frequently asked questions about CineAssets.">
+  <link rel="canonical" href="https://www.cineassets.com/faq.html">
+  <meta property="og:title" content="CineAssets | FAQ">
+  <meta property="og:description" content="Frequently asked questions about CineAssets.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+  <h1 class="text-4xl font-bold mb-8">FAQ</h1>
+  <div class="space-y-8">
+    <div>
+      <h2 class="text-2xl font-semibold mb-2">How do I download my assets?</h2>
+      <p class="text-gray-300">After checkout you'll receive a download link via email and in your account dashboard.</p>
+    </div>
+    <div>
+      <h2 class="text-2xl font-semibold mb-2">Can I use the assets in commercial projects?</h2>
+      <p class="text-gray-300">Yes, all purchases include a license for personal and commercial use unless stated otherwise.</p>
+    </div>
+    <div>
+      <h2 class="text-2xl font-semibold mb-2">Do you offer refunds?</h2>
+      <p class="text-gray-300">Because our products are digital, refunds are handled on a case-by-case basis. Please see our <a href="refund-policy.html" class="text-blue-400 hover:underline">Refund Policy</a>.</p>
+    </div>
+    <div>
+      <h2 class="text-2xl font-semibold mb-2">Do you offer free samples?</h2>
+      <p class="text-gray-300">We occasionally release free assets. Join our newsletter or follow us on social media for announcements.</p>
+    </div>
+    <div>
+      <h2 class="text-2xl font-semibold mb-2">How can I get support?</h2>
+      <p class="text-gray-300">Reach out through our <a href="contact.html" class="text-blue-400 hover:underline">contact form</a> and we'll respond as soon as possible.</p>
+    </div>
+  </div>
+</main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CineAssets | Premium Digital Assets for Filmmakers</title>
+    <meta name="description" content="CineAssets offers premium sound effects, music tracks, LUTs, presets and stock footage for filmmakers and content creators.">
+    <meta name="keywords" content="sound effects,music tracks,LUTs,presets,stock footage,filmmaker assets">
+    <link rel="canonical" href="https://www.cineassets.com/">
+    <meta property="og:title" content="CineAssets | Premium Digital Assets for Filmmakers">
+    <meta property="og:description" content="Premium sound effects, music tracks, LUTs, presets and footage for cinematic content.">
+    <meta property="og:type" content="website">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
@@ -111,23 +117,23 @@
     <nav class="bg-black text-white sticky top-0 z-50 shadow-lg">
         <div class="container mx-auto px-4 py-4 flex justify-between items-center">
             <div class="flex items-center space-x-8">
-                <a href="#" class="text-3xl font-bold tracking-tight cinematic-text">
+                <a href="index.html" class="text-3xl font-bold tracking-tight cinematic-text">
                     <span class="text-blue-400">Cine</span><span>Assets</span>
                 </a>
                 <div class="hidden md:flex space-x-6">
-                    <a href="#" class="hover:text-blue-400 transition">Shop</a>
-                    <a href="#" class="hover:text-blue-400 transition">Bundles</a>
-                    <a href="#" class="hover:text-blue-400 transition">New Releases</a>
+                    <a href="shop.html" class="hover:text-blue-400 transition">Shop</a>
+                    <a href="bundles.html" class="hover:text-blue-400 transition">Bundles</a>
+                    <a href="new-releases.html" class="hover:text-blue-400 transition">New Releases</a>
                     <div class="dropdown relative">
                         <button class="hover:text-blue-400 transition flex items-center">
                             Categories <i class="fas fa-chevron-down ml-1 text-xs"></i>
                         </button>
                         <div class="dropdown-menu absolute left-0 mt-2 w-48 rounded-md shadow-lg py-1 z-50">
-                            <a href="#" class="block px-4 py-2 hover:bg-gray-700">Sound Effects</a>
-                            <a href="#" class="block px-4 py-2 hover:bg-gray-700">Music Tracks</a>
-                            <a href="#" class="block px-4 py-2 hover:bg-gray-700">LUTs</a>
-                            <a href="#" class="block px-4 py-2 hover:bg-gray-700">Preset Packs</a>
-                            <a href="#" class="block px-4 py-2 hover:bg-gray-700">Stock Footage</a>
+                            <a href="sound-effects.html" class="block px-4 py-2 hover:bg-gray-700">Sound Effects</a>
+                            <a href="music-tracks.html" class="block px-4 py-2 hover:bg-gray-700">Music Tracks</a>
+                            <a href="luts.html" class="block px-4 py-2 hover:bg-gray-700">LUTs</a>
+                            <a href="preset-packs.html" class="block px-4 py-2 hover:bg-gray-700">Preset Packs</a>
+                            <a href="stock-footage.html" class="block px-4 py-2 hover:bg-gray-700">Stock Footage</a>
                         </div>
                     </div>
                 </div>
@@ -163,8 +169,8 @@
                 <h1 class="text-5xl md:text-6xl font-bold mb-6 cinematic-text">Elevate Your Filmmaking</h1>
                 <p class="text-xl mb-8 opacity-90">Premium digital assets for filmmakers, editors, and content creators. Cinematic quality, no Hollywood budget.</p>
                 <div class="flex flex-col sm:flex-row justify-center gap-4">
-                    <a href="#" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-lg transition glow-effect">Shop Now</a>
-                    <a href="#" class="bg-transparent hover:bg-gray-800 border border-white text-white font-bold py-3 px-8 rounded-lg transition">View Bundles</a>
+                    <a href="shop.html" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-lg transition glow-effect">Shop Now</a>
+                    <a href="bundles.html" class="bg-transparent hover:bg-gray-800 border border-white text-white font-bold py-3 px-8 rounded-lg transition">View Bundles</a>
                 </div>
             </div>
         </div>
@@ -175,31 +181,31 @@
         <div class="container mx-auto px-4">
             <h2 class="text-4xl font-bold text-center mb-12 section-title cinematic-text">Shop By Category</h2>
             <div class="grid grid-cols-2 md:grid-cols-5 gap-6">
-                <a href="#" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
+                <a href="sound-effects.html" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
                     <div class="bg-blue-900 text-blue-400 rounded-full h-16 w-16 flex items-center justify-center mx-auto mb-4">
                         <i class="fas fa-music text-2xl"></i>
                     </div>
                     <h3 class="font-semibold text-white">Sound FX</h3>
                 </a>
-                <a href="#" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
+                <a href="music-tracks.html" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
                     <div class="bg-purple-900 text-purple-400 rounded-full h-16 w-16 flex items-center justify-center mx-auto mb-4">
                         <i class="fas fa-headphones text-2xl"></i>
                     </div>
                     <h3 class="font-semibold text-white">Music</h3>
                 </a>
-                <a href="#" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
+                <a href="luts.html" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
                     <div class="bg-yellow-900 text-yellow-400 rounded-full h-16 w-16 flex items-center justify-center mx-auto mb-4">
                         <i class="fas fa-palette text-2xl"></i>
                     </div>
                     <h3 class="font-semibold text-white">LUTs</h3>
                 </a>
-                <a href="#" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
+                <a href="preset-packs.html" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
                     <div class="bg-green-900 text-green-400 rounded-full h-16 w-16 flex items-center justify-center mx-auto mb-4">
                         <i class="fas fa-sliders-h text-2xl"></i>
                     </div>
                     <h3 class="font-semibold text-white">Presets</h3>
                 </a>
-                <a href="#" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
+                <a href="stock-footage.html" class="category-card rounded-lg p-6 text-center hover:shadow-lg transition">
                     <div class="bg-red-900 text-red-400 rounded-full h-16 w-16 flex items-center justify-center mx-auto mb-4">
                         <i class="fas fa-video text-2xl"></i>
                     </div>
@@ -214,7 +220,7 @@
         <div class="container mx-auto px-4">
             <div class="flex justify-between items-center mb-8">
                 <h2 class="text-4xl font-bold section-title cinematic-text">Featured Products</h2>
-                <a href="#" class="text-blue-400 hover:underline">View All</a>
+                <a href="shop.html" class="text-blue-400 hover:underline">View All</a>
             </div>
             
             <!-- Filter Bar -->
@@ -453,8 +459,8 @@
             <h2 class="text-4xl font-bold mb-6 section-title cinematic-text">Ready to Upgrade Your Content?</h2>
             <p class="text-xl mb-8 max-w-2xl mx-auto opacity-90">Join thousands of creators who are making professional-quality videos with our digital assets.</p>
             <div class="flex flex-col sm:flex-row justify-center gap-4">
-                <a href="#" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-lg transition glow-effect">Browse All Products</a>
-                <a href="#" class="bg-transparent hover:bg-gray-800 border border-white text-white font-bold py-3 px-8 rounded-lg transition">See Bundle Deals</a>
+                <a href="shop.html" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-8 rounded-lg transition glow-effect">Browse All Products</a>
+                <a href="bundles.html" class="bg-transparent hover:bg-gray-800 border border-white text-white font-bold py-3 px-8 rounded-lg transition">See Bundle Deals</a>
             </div>
         </div>
     </section>
@@ -472,29 +478,29 @@
                 <div>
                     <h4 class="font-bold mb-4 text-white">Shop</h4>
                     <ul class="space-y-2">
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">Sound Effects</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">Music Tracks</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">LUTs</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">Preset Packs</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">Stock Footage</a></li>
+                        <li><a href="sound-effects.html" class="text-gray-400 hover:text-blue-400 transition footer-links">Sound Effects</a></li>
+                        <li><a href="music-tracks.html" class="text-gray-400 hover:text-blue-400 transition footer-links">Music Tracks</a></li>
+                        <li><a href="luts.html" class="text-gray-400 hover:text-blue-400 transition footer-links">LUTs</a></li>
+                        <li><a href="preset-packs.html" class="text-gray-400 hover:text-blue-400 transition footer-links">Preset Packs</a></li>
+                        <li><a href="stock-footage.html" class="text-gray-400 hover:text-blue-400 transition footer-links">Stock Footage</a></li>
                     </ul>
                 </div>
                 <div>
                     <h4 class="font-bold mb-4 text-white">Support</h4>
                     <ul class="space-y-2">
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">FAQ</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">Contact Us</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">License Agreement</a></li>
-                        <li><a href="#" class="text-gray-400 hover:text-blue-400 transition footer-links">Refund Policy</a></li>
+                        <li><a href="faq.html" class="text-gray-400 hover:text-blue-400 transition footer-links">FAQ</a></li>
+                        <li><a href="contact.html" class="text-gray-400 hover:text-blue-400 transition footer-links">Contact Us</a></li>
+                        <li><a href="license-agreement.html" class="text-gray-400 hover:text-blue-400 transition footer-links">License Agreement</a></li>
+                        <li><a href="refund-policy.html" class="text-gray-400 hover:text-blue-400 transition footer-links">Refund Policy</a></li>
                     </ul>
                 </div>
                 <div>
                     <h4 class="font-bold mb-4 text-white">Connect</h4>
                     <div class="flex space-x-4 mb-4">
-                        <a href="#" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-instagram"></i></a>
-                        <a href="#" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-youtube"></i></a>
-                        <a href="#" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-twitter"></i></a>
-                        <a href="#" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-facebook"></i></a>
+                        <a href="https://instagram.com/" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-instagram"></i></a>
+                        <a href="https://youtube.com/" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-youtube"></i></a>
+                        <a href="https://twitter.com/" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-twitter"></i></a>
+                        <a href="https://facebook.com/" class="text-gray-400 hover:text-blue-400 transition"><i class="fab fa-facebook"></i></a>
                     </div>
                     <p class="text-gray-400">Subscribe to our newsletter for updates and deals</p>
                     <div class="mt-3 flex">
@@ -508,8 +514,8 @@
             <div class="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
                 <p class="text-gray-400 text-sm">© 2023 CineAssets. All rights reserved.</p>
                 <div class="flex space-x-6 mt-4 md:mt-0">
-                    <a href="#" class="text-gray-400 hover:text-blue-400 text-sm transition footer-links">Privacy Policy</a>
-                    <a href="#" class="text-gray-400 hover:text-blue-400 text-sm transition footer-links">Terms of Service</a>
+                    <a href="privacy-policy.html" class="text-gray-400 hover:text-blue-400 text-sm transition footer-links">Privacy Policy</a>
+                    <a href="terms-of-service.html" class="text-gray-400 hover:text-blue-400 text-sm transition footer-links">Terms of Service</a>
                 </div>
             </div>
         </div>

--- a/license-agreement.html
+++ b/license-agreement.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | License Agreement</title>
+  <meta name="description" content="Review the licensing terms for using CineAssets products.">
+  <link rel="canonical" href="https://www.cineassets.com/license-agreement.html">
+  <meta property="og:title" content="CineAssets | License Agreement">
+  <meta property="og:description" content="Review the licensing terms for using CineAssets products.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">License Agreement</h1>
+    <p class="text-gray-300">Understand the rights and restrictions for our digital assets.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/luts.html
+++ b/luts.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | LUTs</title>
+  <meta name="description" content="Professional LUTs to enhance your footage.">
+  <link rel="canonical" href="https://www.cineassets.com/luts.html">
+  <meta property="og:title" content="CineAssets | LUTs">
+  <meta property="og:description" content="Professional LUTs to enhance your footage.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">LUTs</h1>
+    <p class="text-gray-300">Color grade with our versatile LUT packs.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/music-tracks.html
+++ b/music-tracks.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Music Tracks</title>
+  <meta name="description" content="Royalty-free music tracks for any production.">
+  <link rel="canonical" href="https://www.cineassets.com/music-tracks.html">
+  <meta property="og:title" content="CineAssets | Music Tracks">
+  <meta property="og:description" content="Royalty-free music tracks for any production.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Music Tracks</h1>
+    <p class="text-gray-300">Find the perfect soundtrack for your videos.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/new-releases.html
+++ b/new-releases.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | New Releases</title>
+  <meta name="description" content="Stay updated with the latest digital assets added to CineAssets.">
+  <link rel="canonical" href="https://www.cineassets.com/new-releases.html">
+  <meta property="og:title" content="CineAssets | New Releases">
+  <meta property="og:description" content="Stay updated with the latest digital assets added to CineAssets.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">New Releases</h1>
+    <p class="text-gray-300">Check out the newest products in our catalog.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/preset-packs.html
+++ b/preset-packs.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Preset Packs</title>
+  <meta name="description" content="Editing preset packs for fast workflows.">
+  <link rel="canonical" href="https://www.cineassets.com/preset-packs.html">
+  <meta property="og:title" content="CineAssets | Preset Packs">
+  <meta property="og:description" content="Editing preset packs for fast workflows.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Preset Packs</h1>
+    <p class="text-gray-300">Speed up your edits with our preset collections.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Privacy Policy</title>
+  <meta name="description" content="Read our privacy policy.">
+  <link rel="canonical" href="https://www.cineassets.com/privacy-policy.html">
+  <meta property="og:title" content="CineAssets | Privacy Policy">
+  <meta property="og:description" content="Read our privacy policy.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Privacy Policy</h1>
+    <p class="text-gray-300">Your privacy matters to us. Review how we handle your data.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/refund-policy.html
+++ b/refund-policy.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Refund Policy</title>
+  <meta name="description" content="Details on our refund policy.">
+  <link rel="canonical" href="https://www.cineassets.com/refund-policy.html">
+  <meta property="og:title" content="CineAssets | Refund Policy">
+  <meta property="og:description" content="Details on our refund policy.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Refund Policy</h1>
+    <p class="text-gray-300">Learn how we handle refunds and returns.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/shop.html
+++ b/shop.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Shop</title>
+  <meta name="description" content="Browse our full catalog of digital assets including sound effects, music tracks, LUTs, presets and stock footage.">
+  <link rel="canonical" href="https://www.cineassets.com/shop.html">
+  <meta property="og:title" content="CineAssets | Shop">
+  <meta property="og:description" content="Browse our full catalog of digital assets including sound effects, music tracks, LUTs, presets and stock footage.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Shop</h1>
+    <p class="text-gray-300">Explore all products available from CineAssets.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/sound-effects.html
+++ b/sound-effects.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Sound Effects</title>
+  <meta name="description" content="High-quality sound effects for film and video projects.">
+  <link rel="canonical" href="https://www.cineassets.com/sound-effects.html">
+  <meta property="og:title" content="CineAssets | Sound Effects">
+  <meta property="og:description" content="High-quality sound effects for film and video projects.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Sound Effects</h1>
+    <p class="text-gray-300">Explore our collection of immersive sound effects.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/stock-footage.html
+++ b/stock-footage.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Stock Footage</title>
+  <meta name="description" content="Cinematic stock footage for your projects.">
+  <link rel="canonical" href="https://www.cineassets.com/stock-footage.html">
+  <meta property="og:title" content="CineAssets | Stock Footage">
+  <meta property="og:description" content="Cinematic stock footage for your projects.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16">
+    <h1 class="text-4xl font-bold mb-4">Stock Footage</h1>
+    <p class="text-gray-300">Download high-quality footage for any production.</p>
+  </main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CineAssets | Terms of Service</title>
+  <meta name="description" content="Terms of service for CineAssets.">
+  <link rel="canonical" href="https://www.cineassets.com/terms-of-service.html">
+  <meta property="og:title" content="CineAssets | Terms of Service">
+  <meta property="og:description" content="Terms of service for CineAssets.">
+  <meta property="og:type" content="website">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-black text-white">
+  <nav class="bg-black text-white py-4">
+  <div class="container mx-auto px-4 flex justify-between items-center">
+    <a href="index.html" class="text-2xl font-bold"><span class="text-blue-400">Cine</span>Assets</a>
+    <ul class="flex space-x-6 text-sm">
+      <li><a href="shop.html" class="hover:text-blue-400">Shop</a></li>
+      <li><a href="bundles.html" class="hover:text-blue-400">Bundles</a></li>
+      <li><a href="new-releases.html" class="hover:text-blue-400">New Releases</a></li>
+      <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+      <li><a href="contact.html" class="hover:text-blue-400">Contact</a></li>
+    </ul>
+  </div>
+</nav>
+  <main class="container mx-auto px-4 py-16 space-y-8">
+  <h1 class="text-4xl font-bold">Terms of Service</h1>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">1. Acceptance of Terms</h2>
+    <p class="text-gray-300">By accessing or using CineAssets, you agree to be bound by these Terms of Service and all applicable laws and regulations.</p>
+  </section>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">2. Use of Assets</h2>
+    <p class="text-gray-300">Purchased assets are licensed, not sold. You may use them in personal or commercial projects, but you may not redistribute or resell them as standalone files.</p>
+  </section>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">3. Payments and Licenses</h2>
+    <p class="text-gray-300">All sales are processed securely through our payment providers. Upon purchase, you receive a non-exclusive, non-transferable license to use the assets.</p>
+  </section>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">4. Refund Policy</h2>
+    <p class="text-gray-300">Due to the digital nature of our products, refunds are only granted in exceptional circumstances as outlined in our Refund Policy.</p>
+  </section>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">5. Intellectual Property</h2>
+    <p class="text-gray-300">All content on CineAssets, including assets, text, graphics, and logos, is the property of CineAssets and protected by intellectual property laws.</p>
+  </section>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">6. Limitation of Liability</h2>
+    <p class="text-gray-300">CineAssets shall not be liable for any indirect, incidental, or consequential damages arising out of the use of our website or products.</p>
+  </section>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">7. Governing Law</h2>
+    <p class="text-gray-300">These Terms are governed by the laws of the jurisdiction in which CineAssets operates, without regard to its conflict of law provisions.</p>
+  </section>
+  <section class="space-y-4">
+    <h2 class="text-2xl font-semibold">8. Contact</h2>
+    <p class="text-gray-300">For any questions about these Terms, please <a href="contact.html" class="text-blue-400 hover:underline">contact us</a>.</p>
+  </section>
+</main>
+  <footer class="bg-black text-white py-12">
+  <div class="container mx-auto px-4 grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div>
+      <h3 class="text-xl font-bold mb-4"><span class="text-blue-400">Cine</span>Assets</h3>
+      <p class="text-gray-400">Premium digital assets for filmmakers, editors, and content creators.</p>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Shop</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="sound-effects.html" class="hover:text-blue-400">Sound Effects</a></li>
+        <li><a href="music-tracks.html" class="hover:text-blue-400">Music Tracks</a></li>
+        <li><a href="luts.html" class="hover:text-blue-400">LUTs</a></li>
+        <li><a href="preset-packs.html" class="hover:text-blue-400">Preset Packs</a></li>
+        <li><a href="stock-footage.html" class="hover:text-blue-400">Stock Footage</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Support</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="faq.html" class="hover:text-blue-400">FAQ</a></li>
+        <li><a href="contact.html" class="hover:text-blue-400">Contact Us</a></li>
+        <li><a href="license-agreement.html" class="hover:text-blue-400">License Agreement</a></li>
+        <li><a href="refund-policy.html" class="hover:text-blue-400">Refund Policy</a></li>
+      </ul>
+    </div>
+    <div>
+      <h4 class="font-bold mb-4">Legal</h4>
+      <ul class="space-y-2 text-gray-400">
+        <li><a href="privacy-policy.html" class="hover:text-blue-400">Privacy Policy</a></li>
+        <li><a href="terms-of-service.html" class="hover:text-blue-400">Terms of Service</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="border-t border-gray-800 mt-8 pt-4 text-center text-gray-400 text-sm">
+    © 2023 CineAssets. All rights reserved.
+  </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SEO meta description, keywords, canonical and Open Graph tags
- replace placeholder links with real pages and social URLs
- add new HTML pages for shop, bundles, releases, categories, and support/legal content
- give each page a consistent header and footer
- populate Terms of Service and FAQ content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943648e4c48323b0137553a8bf3285